### PR TITLE
Maintenance 2022-02-28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,83 +1,116 @@
 name: build
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ "main" ]
   push:
-    branches:
-      - main
+    branches: [ "main" ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
+# Actions
+# shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+
 jobs:
 
-  ci: # this job runs all the development tools
-
-    name: Continuous Integration
+  phpcs:
+    name: Code style (phpcs)
     runs-on: "ubuntu-latest"
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4' # cannot use php 8.0 because phpunit dependency to create code coverage
-          coverage: xdebug
-          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, phpcs
         env:
           fail-fast: true
+      - name: Code style (phpcs)
+        run: phpcs -q --report=checkstyle | cs2pr
 
+  php-cs-fixer:
+    name: Code style (php-cs-fixer)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, php-cs-fixer
+        env:
+          fail-fast: true
+      - name: Code style (php-cs-fixer)
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+
+  phpstan:
+    name: Code analysis (phpstan)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, phpstan
+        env:
+          fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: PHPStan
+        run: phpstan analyse --no-progress
 
-      - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle | cs2pr
-
-      - name: Code style (php-cs-fixer)
-        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-
-      - name: Code analysis (phpstan)
-        run: phpstan analyse --no-progress --verbose
-
-      - name: Code analysis (psalm)
+  psalm:
+    name: Code analysis (psalm)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, psalm
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Psalm
         run: psalm --no-progress
 
-      - name: Mutation testing (infection)
-        # run this way because infection phar is not working on php 7.4
-        run: |
-          composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
-          vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github
-
-  test:
-
-    name: Test on PHP ${{ matrix.php-versions }}
+  tests:
+    name: Tests on PHP ${{ matrix.php-versions }}
     runs-on: "ubuntu-latest"
-
     strategy:
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -86,20 +119,47 @@ jobs:
           tools: composer:v2
         env:
           fail-fast: true
-
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Tests
+      - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
+
+  infection:
+    name: Mutation testing (infection)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4' # code coverage cannot be made with phpunit 8 and php >= 8.0
+          coverage: xdebug
+          tools: composer:v2
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Mutation testing
+        # run this way because infection phar is not working on php 7.4
+        run: |
+          composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
+          vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.5.0" installed="3.5.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.20.0" installed="4.20.0" location="./tools/psalm" copy="false"/>
+  <phar name="psalm" version="^4.22.0" installed="4.22.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,50 +1,50 @@
 <?php
 
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
-        '@PHP71Migration' => true,
+        '@PSR12' => true,
+        '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
+        '@PHP73Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'no_alias_functions' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
-        'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
+        'not_operator_with_successor_space' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
+            ->append([__FILE__])
             ->exclude(['vendor', 'tools', 'build'])
     )
 ;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `eclipxe/enum`
 
 [![Source Code][badge-source]][source]
+[![Packagist PHP Version Support][badge-php-version]][php-version]
 [![Latest Version][badge-release]][release]
 [![Software License][badge-license]][license]
 [![Build Status][badge-build]][build]
@@ -267,6 +268,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [todo]: https://github.com/eclipxe13/enum/blob/main/docs/TODO.md
 
 [source]: https://github.com/eclipxe13/enum
+[php-version]: https://packagist.org/packages/eclipxe/enum
 [release]: https://github.com/eclipxe13/enum/releases
 [license]: https://github.com/eclipxe13/enum/blob/main/LICENSE
 [build]: https://github.com/eclipxe13/enum/actions/workflows/build.yml?query=branch:main
@@ -275,6 +277,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [downloads]: https://packagist.org/packages/eclipxe/enum
 
 [badge-source]: https://img.shields.io/badge/source-eclipxe13/enum-blue?style=flat-square
+[badge-php-version]: https://img.shields.io/packagist/php-v/eclipxe/enum?style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/enum?style=flat-square
 [badge-license]: https://img.shields.io/github/license/eclipxe13/enum?style=flat-square
 [badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/enum/build/main?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## UNRELEASED 2022-02-28
+
+This is a maintenance update:
+
+- Fixed CI. Remove Psalm deprecated attribute `totallyTyped`.
+- On GitHub workflow for CI, split steps into jobs.
+- Update code style rules.
+- Add PHP Version badge on README.
+
 ## UNRELEASED 2022-02-06
 
 Update license year. Happy 2022!

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,8 +9,9 @@
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
+    <arg name="cache" value="build/phpcs.cache"/>
 
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/tests/Unit/EnumExtendedClassesTest.php
+++ b/tests/Unit/EnumExtendedClassesTest.php
@@ -66,7 +66,7 @@ class EnumExtendedClassesTest extends TestCase
 
     public function testTypeHierarchy(): void
     {
-        $consumer = new class() {
+        $consumer = new class () {
             public function sample(ColorsBasic $color): bool
             {
                 return $color->isRed();
@@ -91,7 +91,7 @@ class EnumExtendedClassesTest extends TestCase
             sprintf('sample(ColorsBasic) must receive %s (extended)', get_class($extCyan))
         );
 
-        $inline = new class('red') extends ColorsExtended {
+        $inline = new class ('red') extends ColorsExtended {
         };
         $this->assertTrue(
             $consumer->sample($inline),


### PR DESCRIPTION
- Fixed CI. Remove Psalm deprecated attribute `totallyTyped`.
- On GitHub workflow for CI, split steps into jobs.
- Update code style rules.
- Add PHP Version badge on README.
