### PR TITLE
Maintenance 2023-05-24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -90,7 +90,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -121,7 +121,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -149,7 +149,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,9 +142,9 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4' # code coverage cannot be made with phpunit 8 and php >= 8.0
+          php-version: '8.2'
           coverage: xdebug
-          tools: composer:v2
+          tools: composer:v2, infection
         env:
           fail-fast: true
       - name: Get composer cache directory
@@ -157,9 +157,13 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: Mutation testing
-        # run this way because infection phar is not working on php 7.4
         run: |
-          composer require --dev infection/infection --no-interaction --no-progress --prefer-dist
-          vendor/bin/infection --no-progress --no-interaction --show-mutations --logger-github
+          composer require 'php:>=8.2' --no-install
+          composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
+          composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Upgrade PHPUnit configuration file
+        run: |
+          vendor/bin/phpunit --migrate-configuration
+          sed -i -E 's/executionOrder=".*?"/executionOrder="default"/' phpunit.xml.dist
+      - name: Mutation testing
+        run: infection --no-progress --no-interaction --show-mutations --logger-github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, phpcs
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, php-cs-fixer
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -83,7 +83,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, psalm
         env:
@@ -107,7 +107,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -40,7 +40,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -5,5 +5,5 @@
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^1.10.15" installed="1.10.15" location="./tools/phpstan" copy="false"/>
   <phar name="psalm" version="^4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.27.0" location="./tools/infection" copy="false" installed="0.27.0"/>
+  <phar name="infection" version="^0.24.0" location="./tools/infection" copy="false" installed="0.24.0"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.9.4" installed="3.9.4" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.8.1" installed="1.8.1" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.24.0" installed="4.24.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.23.0" location="./tools/infection" copy="false" installed="0.23.0"/>
+  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.15" installed="1.10.15" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.27.0" location="./tools/infection" copy="false" installed="0.27.0"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,17 +18,17 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // symfony
-        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -36,11 +36,13 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,12 +6,16 @@ filter:
 build:
   dependencies:
     override:
+      - composer require 'php:>=8.2' --no-install
+      - composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
       - composer upgrade --no-interaction --prefer-dist
+      - vendor/bin/phpunit --migrate-configuration
+      - sed -i -E 's/executionOrder=".*?"/executionOrder="default"/' phpunit.xml.dist
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
       environment:
         php:
-          version: 7.4
+          version: 8.2
       project_setup: { override: true }
       tests:
         override:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2022 Carlos C Soto
+Copyright (c) 2019 - 2023 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/eclipxe/enum?style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/enum?style=flat-square
 [badge-license]: https://img.shields.io/github/license/eclipxe13/enum?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/enum/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/eclipxe13/enum/build.yml?branch=main&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/eclipxe13/enum/main?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/enum/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/enum?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
             "@php tools/phpstan analyse --no-progress",
-            "@php tools/psalm --no-progress",
-            "@dev:infection"
+            "@php tools/psalm --no-progress"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
@@ -64,8 +63,8 @@
         "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit, phpstan, psalm and infection",
+        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit, phpstan and psalm",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
-        "dev:infection": "DEV: run mutation tests using infection"
+        "dev:infection": "DEV: run mutation tests using infection (use PHP 7.4)"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,12 +10,31 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## UNRELEASED 2023-05-24
+
+This is a maintenance update:
+
+- Fix false positive PHPStan issue.
+- Update license year.
+- Fix badge build on `README.md`.
+- Fix GitHub workflow:
+  - Run tools on PHP 8.2.
+  - Refactor infection job to run on PHP 8.2.
+  - Replace `::set-output` with `$GITHUB_OUTPUT`.
+  - Remove composer tool when is not required.
+- Fix Scrutinizer CI to run on PHP 8.2.
+- Update `php-cs-fixer` configuration:
+  - Fix `no_trailing_comma_in_singleline`.
+  - Add `fully_qualified_strict_types`.
+  - Add `trailing_comma_in_multiline`. 
+- Update development tools.
+
 ## UNRELEASED 2022-07-18
 
 This is a maintenance update:
 
 - Fixed CI. Add configuration for `infection/extension-installer` (deny).
-- Add ordered imports to `php-cs-fixer` connfiguration.
+- Add ordered imports to `php-cs-fixer` configuration.
 - Update development tools.
 - Fix Scrutinizer CI to run on PHP 7.4.
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -47,7 +47,7 @@ abstract class Enum
         // convert to string if object
         if (is_object($valueOrIndex)) {
             try {
-                $valueOrIndex = strval($valueOrIndex);
+                $valueOrIndex = strval($valueOrIndex); // @phpstan-ignore-line
             } catch (Throwable $exception) {
                 throw EnumConstructTypeError::create(static::class, $exception);
             }


### PR DESCRIPTION
This is a maintenance update:

- Fix false positive PHPStan issue.
- Update license year.
- Fix badge build on `README.md`.
- Fix GitHub workflow:
  - Run tools on PHP 8.2.
  - Refactor infection job to run on PHP 8.2.
  - Replace `::set-output` with `$GITHUB_OUTPUT`.
  - Remove composer tool when is not required.
- Fix Scrutinizer CI to run on PHP 8.2.
- Update `php-cs-fixer` configuration:
  - Fix `no_trailing_comma_in_singleline`.
  - Add `fully_qualified_strict_types`.
  - Add `trailing_comma_in_multiline`. 
- Update development tools.
