### PR TITLE
Maintenance 2024-03-18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,41 +137,6 @@ jobs:
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
 
-  infection:
-    name: Mutation testing (infection)
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          coverage: xdebug
-          tools: composer:v2, infection
-        env:
-          fail-fast: true
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Install project dependencies
-        run: |
-          composer require 'php:>=8.3' --no-install
-          composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
-          composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: Upgrade PHPUnit configuration file
-        run: |
-          vendor/bin/phpunit --migrate-configuration
-          sed -i -E 's/executionOrder=".*?"/executionOrder="default"/' phpunit.xml.dist
-      - name: Mutation testing
-        run: infection --no-progress --no-interaction --show-mutations --logger-github
-
   code-coverage:
     name: Create code coverage
     runs-on: "ubuntu-latest"
@@ -231,3 +196,40 @@ jobs:
         uses: sudo-bot/action-scrutinizer@latest
         with:
           cli-args: "--format=php-clover build/coverage/clover.xml"
+
+  infection:
+    name: Mutation testing (infection)
+    needs: code-coverage
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2, infection
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: |
+          composer require 'php:>=8.3' --no-install
+          composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
+          composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Obtain code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage
+          path: build/coverage
+      - name: Mutation testing
+        run: infection --skip-initial-tests --coverage=build/coverage --no-progress --no-interaction --logger-github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -83,7 +83,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, psalm
         env:
@@ -144,7 +144,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2, infection
         env:
@@ -160,7 +160,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: |
-          composer require 'php:>=8.2' --no-install
+          composer require 'php:>=8.3' --no-install
           composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
           composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Upgrade PHPUnit configuration file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -51,7 +51,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -64,7 +64,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -79,7 +79,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -110,7 +110,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -123,7 +123,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -138,7 +138,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -151,7 +151,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+# sudo-bot/action-scrutinizer@latest https://github.com/marketplace/actions/action-scrutinizer
 
 jobs:
 
@@ -170,3 +171,63 @@ jobs:
           sed -i -E 's/executionOrder=".*?"/executionOrder="default"/' phpunit.xml.dist
       - name: Mutation testing
         run: infection --no-progress --no-interaction --show-mutations --logger-github
+
+  code-coverage:
+    name: Create code coverage
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: xdebug
+          tools: composer:v2
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: |
+          composer require 'php:>=8.3' --no-install
+          composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
+          composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Upgrade PHPUnit configuration file
+        run: |
+          vendor/bin/phpunit --migrate-configuration
+          sed -i -E 's/executionOrder=".*?"/executionOrder="default"/' phpunit.xml.dist
+      - name: Create code coverage
+        run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+      - name: Store code coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: build/coverage
+
+  scrutinizer:
+    name: Upload code coverage
+    needs: code-coverage
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for sudo-bot/action-scrutinizer
+      - name: Obtain code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage
+          path: build/coverage
+      - name: Upload code coverage to scrutinizer
+        if: ${{ !env.ACT }} # do not run if using nektos/act
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover build/coverage/clover.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,18 +105,18 @@ jobs:
         run: psalm --no-progress
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Psalm version
+        run: psalm --version
       - name: Psalm
         run: psalm --no-progress
 

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.15" installed="1.10.15" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.24.0" location="./tools/infection" copy="false" installed="0.24.0"/>
+  <phar name="php-cs-fixer" version="^3.57.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.9.0" installed="3.9.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.9.0" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.62" installed="1.10.62" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.23.1" installed="5.23.1" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.27.10" installed="0.27.10" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,23 +4,11 @@ filter:
     - 'vendor/'
 
 build:
-  dependencies:
-    override:
-      - composer require 'php:>=8.2' --no-install
-      - composer require phpunit/phpunit:^9 --dev --update-with-all-dependencies --no-install
-      - composer upgrade --no-interaction --prefer-dist
-      - vendor/bin/phpunit --migrate-configuration
-      - sed -i -E 's/executionOrder=".*?"/executionOrder="default"/' phpunit.xml.dist
+  dependencies: { override: true }
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
-      environment:
-        php:
-          version: 8.2
       project_setup: { override: true }
-      tests:
-        override:
-          - php-scrutinizer-run --enable-security-analysis
-          - command: php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
-            coverage:
-              file: coverage.clover
-              format: clover
+      tests: { override: true }
+
+tools:
+  external_code_coverage: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2023 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2019 - 2024 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ my expectations. Maybe spatie/enum version 1.0 was more close to what I needed.
 
 So, I created this framework-agnostic implementation library about the same concept.
 
-As of PHP 8.1 enums will be part of the language, it means that this library will not be required anymore. 
-Check the RFC <https://wiki.php.net/rfc/enumerations> and adapt your code to use PHP Enums.
+As of PHP 8.1 enums are part of the language, it means that this library will not be required anymore. 
+Read the PHP documentation <https://www.php.net/manual/en/language.enumerations.php> and adapt your code.
+One big difference between PHP enums and the objects on this library is that native PHP enums cannot
+use the magic method `__toString` (they are not *`Stringable`*), and the enums on this library are.
 
 ## Installation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,21 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## UNRELEASED 2024-03-18
+
+This is a maintenance update:
+
+- Update documentation about PHP Native enums.
+- Update license year.
+- Update coding standards.
+- Fix GitHub workflow:
+  - Add PHP 8.3 to test matrix.
+  - Run jobs using PHP 8.3.
+  - Use GitHub actions version 4.
+  - Show PSalm version before run.
+  - Allow dispatch workflows manually.
+- Update development tools.
+
 ## UNRELEASED 2023-05-24
 
 This is a maintenance update:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
-
-    <file>src</file>
-    <file>tests</file>
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Personal">
+    <description>Personal coding standard.</description>
 
     <arg name="tab-width" value="4"/>
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
     <arg name="cache" value="build/phpcs.cache"/>
+
+    <file>src/</file>
+    <file>tests/</file>
 
     <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>


### PR DESCRIPTION
- Update documentation about PHP Native enums.
- Update license year.
- Update coding standards.
- Fix GitHub workflow:
  - Add PHP 8.3 to test matrix.
  - Run jobs using PHP 8.3.
  - Use GitHub actions version 4.
  - Show PSalm version before run.
  - Allow dispatch workflows manually.
- Update development tools.
