### PR TITLE
Add compatibility with PHP 8.4 (version 0.2.7)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.64.0" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.10.2" installed="3.10.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.2" installed="3.10.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.12.0" installed="1.12.0" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.25.0" installed="5.25.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.27.11" installed="0.27.11" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.74.0" installed="3.74.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.12.0" installed="3.12.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.12.0" installed="3.12.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.11" installed="2.1.11" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^6.9.6" installed="6.9.6" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2024 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2019 - 2025 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,20 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## Version 0.2.7 2025-03-29
+
+This is a compatibility release with PHP 8.4.
+Added nullable type indicator `?` when default parameter value is `null`.
+
+The license year has been updated.
+
+Maintenance changes:
+
+- On GitHub workflow, add PHP 8.4 to test matrix.
+- Update PSalm configuration to ignore false positives.
+
+This release include all previous unreleased entries.
+
 ## UNRELEASED 2024-09-03
 
 This is a maintenance update:

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config https://raw.githubusercontent.com/vimeo/psalm/refs/heads/6.x/config.xsd"
 >
     <projectFiles>
         <directory name="src" />
@@ -15,5 +14,8 @@
 
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info" />
+        <ClassMustBeFinal errorLevel="info" />
+        <PossiblyUnusedMethod errorLevel="info" />
+        <PossiblyUnusedParam errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -178,7 +178,7 @@ abstract class Enum
         if ('' === $parentClass || self::class === $parentClass) {
             return new Entries();
         }
-        /** @var Enum $parentClass */
+        /** @var class-string<Enum> $parentClass */
         return $parentClass::currentEntries();
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -78,7 +78,7 @@ abstract class Enum
     public function __call(string $name, array $arguments)
     {
         if (strlen($name) > 2 && 'is' === substr($name, 0, 2)) {
-            $entry = static::currentEntries()->findEntryByName(substr($name, 2));
+            $entry = static::currentEntries()->findEntryByName((string) substr($name, 2));
             return (null !== $entry && $this->content->equals($entry));
         }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -79,7 +79,7 @@ abstract class Enum
     {
         if (strlen($name) > 2 && 'is' === substr($name, 0, 2)) {
             $entry = static::currentEntries()->findEntryByName((string) substr($name, 2));
-            return (null !== $entry && $this->content->equals($entry));
+            return null !== $entry && $this->content->equals($entry);
         }
 
         throw BadMethodCallException::create(static::class, $name);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -38,8 +38,8 @@ abstract class Enum
      *
      * @param string|int|mixed $valueOrIndex
      *
-     * @throws IndexNotFoundException if received argument is an integer and it was not found in indices
-     * @throws ValueNotFoundException if received argument is a string and it was not found in values
+     * @throws IndexNotFoundException if received argument is an integer, and it was not found in indices
+     * @throws ValueNotFoundException if received argument is a string, and it was not found in values
      * @throws EnumConstructTypeError if received argument is not an integer, string, scalar or object
      */
     final public function __construct($valueOrIndex)
@@ -53,7 +53,7 @@ abstract class Enum
             }
         }
 
-        if (is_int($valueOrIndex)) { // is index
+        if (is_int($valueOrIndex)) { // is integer index
             $entry = static::currentEntries()->findEntryByIndex($valueOrIndex);
             if (null === $entry) {
                 throw IndexNotFoundException::create(static::class, strval($valueOrIndex));
@@ -174,7 +174,7 @@ abstract class Enum
     final protected static function parentEntries(): Entries
     {
         $parentClass = strval(get_parent_class(static::class));
-        // if does not have a parent class or is the base template (Enum class)
+        // if it does not have a parent class or is the base template (Enum class)
         if ('' === $parentClass || self::class === $parentClass) {
             return new Entries();
         }

--- a/src/Exceptions/BadMethodCallException.php
+++ b/src/Exceptions/BadMethodCallException.php
@@ -11,7 +11,7 @@ class BadMethodCallException extends PhpBadMethodCallException implements EnumEx
 {
     private const EXCODE = 0;
 
-    public static function create(string $className, string $methodName, Throwable $previous = null): self
+    public static function create(string $className, string $methodName, ?Throwable $previous = null): self
     {
         $message = sprintf('Call to undefined method %s::%s', $className, $methodName);
         return new self($message, self::EXCODE, $previous);

--- a/src/Exceptions/EnumConstructTypeError.php
+++ b/src/Exceptions/EnumConstructTypeError.php
@@ -11,7 +11,7 @@ class EnumConstructTypeError extends TypeError implements EnumExceptionInterface
 {
     private const EXCODE = 0;
 
-    public static function create(string $className, Throwable $previous = null): self
+    public static function create(string $className, ?Throwable $previous = null): self
     {
         $message = sprintf('Argument passed to %s must be integer for index or string for value', $className);
         return new self($message, self::EXCODE, $previous);

--- a/src/Exceptions/IndexNotFoundException.php
+++ b/src/Exceptions/IndexNotFoundException.php
@@ -10,7 +10,7 @@ class IndexNotFoundException extends GenericNotFoundException
 {
     private const EXCODE = 0;
 
-    public static function create(string $className, string $value, Throwable $previous = null): self
+    public static function create(string $className, string $value, ?Throwable $previous = null): self
     {
         // StatusEnum index x was not found
         return new self(static::formatGenericMessage($className, 'index', $value), self::EXCODE, $previous);

--- a/src/Exceptions/IndexOverrideException.php
+++ b/src/Exceptions/IndexOverrideException.php
@@ -10,7 +10,7 @@ class IndexOverrideException extends GenericOverrideException
 {
     private const EXCODE = 0;
 
-    public static function create(string $className, string $value, Throwable $previous = null): self
+    public static function create(string $className, string $value, ?Throwable $previous = null): self
     {
         // StatusEnum cannot override index to x
         return new self(static::formatGenericMessage($className, 'index', $value), self::EXCODE, $previous);

--- a/src/Exceptions/ValueNotFoundException.php
+++ b/src/Exceptions/ValueNotFoundException.php
@@ -10,7 +10,7 @@ class ValueNotFoundException extends GenericNotFoundException
 {
     private const EXCODE = 0;
 
-    public static function create(string $className, string $value, Throwable $previous = null): self
+    public static function create(string $className, string $value, ?Throwable $previous = null): self
     {
         // StatusEnum value x was not found
         return new self(static::formatGenericMessage($className, 'value', $value), self::EXCODE, $previous);

--- a/src/Exceptions/ValueOverrideException.php
+++ b/src/Exceptions/ValueOverrideException.php
@@ -10,7 +10,7 @@ class ValueOverrideException extends GenericOverrideException
 {
     private const EXCODE = 0;
 
-    public static function create(string $className, string $value, Throwable $previous = null): self
+    public static function create(string $className, string $value, ?Throwable $previous = null): self
     {
         // StatusEnum cannot override value to x
         return new self(static::formatGenericMessage($className, 'value', $value), self::EXCODE, $previous);

--- a/src/Internal/Entry.php
+++ b/src/Internal/Entry.php
@@ -36,16 +36,16 @@ class Entry
 
     public function equals(self $other): bool
     {
-        return ($this->equalValue($other->value()) && $this->equalIndex($other->index()));
+        return $this->equalValue($other->value()) && $this->equalIndex($other->index());
     }
 
     public function equalValue(string $value): bool
     {
-        return (0 === strcmp($this->value, $value));
+        return 0 === strcmp($this->value, $value);
     }
 
     public function equalIndex(int $index): bool
     {
-        return ($this->index === $index);
+        return $this->index === $index;
     }
 }

--- a/tests/Unit/EnumBasicTest.php
+++ b/tests/Unit/EnumBasicTest.php
@@ -44,7 +44,7 @@ class EnumBasicTest extends TestCase
     public function testCreateEnumCallingStaticMethodWithDifferentCase(): void
     {
         /** @var Stages $stage */
-        $stage = Stages::{'PUBLISHED'}();
+        $stage = Stages::{'PUBLISHED'}(); /** @phpstan-ignore staticMethod.notFound */
         $this->assertSame('published', $stage->value());
         $this->assertSame(1, $stage->index());
     }
@@ -74,7 +74,7 @@ class EnumBasicTest extends TestCase
     public function testMagicMethodIsWithNonDeclaredName(): void
     {
         $stage = Stages::published();
-        $this->assertFalse($stage->{'isNotDeclaredName'}());
+        $this->assertFalse($stage->{'isNotDeclaredName'}()); /** @phpstan-ignore method.notFound */
     }
 
     public function testMagicMethodToString(): void
@@ -124,7 +124,7 @@ class EnumBasicTest extends TestCase
         $notDeclaredName = 'notDeclaredName';
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(sprintf('Call to undefined method %s::%s', Stages::class, $notDeclaredName));
-        Stages::{$notDeclaredName}();
+        Stages::{$notDeclaredName}(); /** @phpstan-ignore staticMethod.notFound */
     }
 
     /**

--- a/tests/Unit/Internal/EntriesPopulatorTest.php
+++ b/tests/Unit/Internal/EntriesPopulatorTest.php
@@ -55,9 +55,8 @@ class EntriesPopulatorTest extends TestCase
      */
     public function testResolveNamesFromDocCommentSelf(string $specimen, array $expected): void
     {
-        /** @var class-string $className */
         $className = 'foo';
-        $helper = new EntriesPopulator($className, [], [], new Entries());
+        $helper = new EntriesPopulator($className, [], [], new Entries()); /** @phpstan-ignore argument.type */
         $resolved = $helper->resolveNamesFromDocComment($specimen);
         $this->assertSame($expected, $resolved);
     }
@@ -69,10 +68,9 @@ class EntriesPopulatorTest extends TestCase
      */
     public function testResolveNamesFromDocCommentStatic(string $specimen, array $expected): void
     {
-        /** @var class-string $className */
         $className = 'foo';
         $specimen = str_replace('self', 'static', $specimen);
-        $helper = new EntriesPopulator($className, [], [], new Entries());
+        $helper = new EntriesPopulator($className, [], [], new Entries());  /** @phpstan-ignore argument.type */
         $resolved = $helper->resolveNamesFromDocComment($specimen);
         $this->assertSame($expected, $resolved);
     }


### PR DESCRIPTION
This is a compatibility release with PHP 8.4.
Added nullable type indicator `?` when default parameter value is `null`.

The license year has been updated.

Maintenance changes:

- On GitHub workflow, add PHP 8.4 to test matrix.
- Update PSalm configuration to ignore false positives.