### PR TITLE
Fix build and test PHP 8.5 compatibility (version 0.2.8)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,15 +2,14 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
-/vendor                     export-ignore
-/tools                      export-ignore
+/vendor/                    export-ignore
+/tools/                     export-ignore
 /composer.lock              export-ignore
 
 # Do not put this files on a distribution package
 /.github/                   export-ignore
 /.phive/                    export-ignore
 /build/                     export-ignore
-/develop/                   export-ignore
 /tests/                     export-ignore
 /.gitattributes             export-ignore
 /.gitignore                 export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   phpcs:
-    name: Code style (phpcs)
+    name: Coding standards (phpcs)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -28,11 +28,11 @@ jobs:
           tools: cs2pr, phpcs
         env:
           fail-fast: true
-      - name: Code style (phpcs)
+      - name: Coding standards (phpcs)
         run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
-    name: Code style (php-cs-fixer)
+    name: Coding standards (php-cs-fixer)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -45,11 +45,11 @@ jobs:
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
-      - name: Code style (php-cs-fixer)
+      - name: Coding standards (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
   phpstan:
-    name: Code analysis (phpstan)
+    name: Static analysis (phpstan)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -73,11 +73,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: PHPStan
-        run: phpstan analyse --no-progress
+      - name: Static analysis (phpstan)
+        run: phpstan analyse --no-progress --verbose
 
   psalm:
-    name: Code analysis (psalm)
+    name: Static analysis (psalm)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -103,11 +103,11 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Psalm version
         run: psalm --version
-      - name: Psalm
+      - name: Static analysis (psalm)
         run: psalm --no-progress
 
   tests:
-    name: Tests on PHP ${{ matrix.php-version }}
+    name: Tests on PHP ${{ matrix.php-version }} (phpunit)
     runs-on: "ubuntu-latest"
     strategy:
       matrix:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.74.0" installed="3.74.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.12.0" installed="3.12.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.12.0" installed="3.12.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^2.1.11" installed="2.1.11" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^6.9.6" installed="6.9.6" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.92.5" installed="3.92.5" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.36" installed="2.1.36" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^6.13.1" installed="6.13.1" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.31.9" installed="0.31.9" location="./tools/infection" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2025 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2019 - 2026 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,17 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## Version 0.2.8 2026-03-16
+
+The license year has been updated.
+
+Maintenance changes:
+
+- On GitHub workflow, add PHP 8.5 to test matrix.
+- Remove deprecated rule for `phpcs`. This change fixes build workflow.
+- Improve `.githubignore` by removing non existent directory.
+- Update development tools.
+
 ## Version 0.2.7 2025-03-29
 
 This is a compatibility release with PHP 8.4.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>


### PR DESCRIPTION
The license year has been updated.

Maintenance changes:

- On GitHub workflow, add PHP 8.5 to test matrix.
- Remove deprecated rule for `phpcs`. This change fixes build workflow.
- Improve `.githubignore` by removing non existent directory.
- Update development tools.

